### PR TITLE
feat: 3-legged oAuthFlow for GitHub

### DIFF
--- a/config/resty.go
+++ b/config/resty.go
@@ -16,5 +16,5 @@ func init() {
 		SetRetryCount(3).
 		SetRetryWaitTime(1000).
 		SetRetryMaxWaitTime(5000).
-		SetTimeout(30 * 1000) // 30 seconds timeout
+		SetTimeout(30 * time.Second) // 30 seconds timeout
 }

--- a/config/resty.go
+++ b/config/resty.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"github.com/go-resty/resty/v2"
+)
+
+var (
+	RestClient *resty.Client
+)
+
+func init() {
+	RestClient = resty.New().
+		SetHeader("User-Agent", "Axon CI Server").
+		SetHeader("Accept", "application/json").
+		SetHeader("Content-Type", "application/json").
+		SetRetryCount(3).
+		SetRetryWaitTime(1000).
+		SetRetryMaxWaitTime(5000).
+		SetTimeout(30 * 1000) // 30 seconds timeout
+}

--- a/controllers/types.go
+++ b/controllers/types.go
@@ -1,0 +1,12 @@
+package controllers
+
+type ErrorResponse struct {
+	Message   string      `json:"message"`
+	Data      interface{} `json:"data,omitempty"`       // Can be nil
+	ErrorCode *int        `json:"error_code,omitempty"` // Optional error code for more specific error handling
+}
+
+type SuccessResponse struct {
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}

--- a/controllers/users/main.go
+++ b/controllers/users/main.go
@@ -66,7 +66,7 @@ func OAuthCallback(c echo.Context) error {
 	if resp.IsError() {
 		return c.JSON(resp.StatusCode(), map[string]map[string]string{
 			"data": {
-				"message": "GitHub returned error",
+				"message": "GitHub returned error: " + resp.String(),
 			},
 		})
 	}
@@ -78,7 +78,7 @@ func OAuthCallback(c echo.Context) error {
 		})
 	}
 
-	print(result.AccessToken)
+	// Removed printing of access token to prevent sensitive credential exposure.
 
 	return c.JSON(http.StatusOK, map[string]map[string]string{
 		"data": {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.9
 
 require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/go-resty/resty/v2 v2.16.5 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/labstack/echo/v4 v4.13.4 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
+github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcXEA=

--- a/routes/users/main.go
+++ b/routes/users/main.go
@@ -11,4 +11,5 @@ func Routes(e *echo.Group) {
 
 	// User Routes
 	Router.GET("/OAuthURL", users.OAuthInitiate)
+	Router.GET("/OAuthCallback", users.OAuthCallback)
 }


### PR DESCRIPTION
This pull request introduces functionality for handling OAuth callbacks in the application, enabling users to complete the OAuth flow with GitHub. The changes include adding a new method for processing the callback, updating dependencies, and registering the new route.

### OAuth Callback Implementation:

* [`controllers/users/main.go`](diffhunk://#diff-ba9d8153f68dae4d27cc9de40e3ed91262a427d206cb311d386d401ff6191e88R29-R88): Added the `OAuthCallback` function to handle the OAuth callback from GitHub, which includes validating the authorization code, making a request to GitHub's token endpoint, and responding with appropriate messages based on the outcome.

### Dependency Updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R9): Added the `github.com/go-resty/resty/v2` dependency for making HTTP requests in the OAuth callback implementation.

### Route Registration:

* [`routes/users/main.go`](diffhunk://#diff-511c1909ec8ec99d6bdeded4c33ce6377489cd0863b28038fd5e0c40c574fc0fR14): Registered the new `OAuthCallback` route to handle incoming callback requests from GitHub.

### Minor Import Update:

* [`controllers/users/main.go`](diffhunk://#diff-ba9d8153f68dae4d27cc9de40e3ed91262a427d206cb311d386d401ff6191e88R4): Added the import for `github.com/go-resty/resty/v2` to support HTTP requests in the OAuth callback implementation.